### PR TITLE
Fix Redis configuration for persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN cp /etc/cron.daily/logrotate /etc/cron.hourly
 
 # redis
 RUN rm /etc/service/redis/down
+RUN sed -i 's/^\(stop-writes-on-bgsave-error .*\)$/stop-writes-on-bgsave-error no/' /etc/redis/redis.conf && \
+echo vm.overcommit_memory = 1 >> /etc/sysctl.conf
 
 # setup gems
 WORKDIR /tmp


### PR DESCRIPTION
Per the faq, set overcommit_memory flag to 1 (basically, assume that
memory is always available instead of checking it). Moreover, fail
silently if unable to write RDB snapshots to disk. Fixes #50.