### PR TITLE
Remove unnecessary reciter from audio response

### DIFF
--- a/app/models/audio/file.rb
+++ b/app/models/audio/file.rb
@@ -31,6 +31,6 @@ class Audio::File < ActiveRecord::Base
     ayah = ayah_key.split(':')[1]
 
 
-    super(only: [:duration, :url, :encrypted_segments], include: :reciter)
+    super(only: [:duration, :url, :encrypted_segments])
   end
 end

--- a/app/models/quran/ayah.rb
+++ b/app/models/quran/ayah.rb
@@ -92,7 +92,6 @@ class Quran::Ayah < ActiveRecord::Base
     if audio_option = options[:audio]
       audio =
         Audio::File
-        .preload(:reciter)
         .where(ayah_key: keys, recitation_id: audio_option, is_enabled: true)
         .order(:ayah_key)
         .group_by(&:ayah_key)


### PR DESCRIPTION
The audio structure in the json was repeated per ayah - this is not
necessary (as a matter of fact, it's not needed at all, since the
reciter id is already known before making this call). This saves a
database query and a very small amount of transfer (4k uncompressed,
much less compressed (~100 bytes)).