### PR TITLE
Don't return font numbers in search api

### DIFF
--- a/app/models/search/results.rb
+++ b/app/models/search/results.rb
@@ -70,12 +70,13 @@ module Search
                 ayah_result[:ayah][:words].find{|word| word['word_id'] == id.to_i}[:highlight] = word_id_array.first
               end
             end
+            nil
+          else
+            hash
           end
-
-          hash
         end
 
-        ayah_result.merge!(match: match)
+        ayah_result.merge!(match: match.compact)
 
         ayah_result
       end


### PR DESCRIPTION
When we do a search, we also search the fonts - we use the information from
these to properly highlight the results. While this is all good, we should
not be returning these results back from the api. This patch fixes that by
returning a nil from that block, and then compacting the match array in
order to remove the nil element before returning. Fixes #63.