### PR TITLE
Remove extra passenger_ruby from nginx config

### DIFF
--- a/docker/backend.quran.com
+++ b/docker/backend.quran.com
@@ -8,7 +8,6 @@ server {
   location / {
     passenger_enabled on;
     passenger_user app;
-    passenger_ruby /usr/bin/ruby2.3;
     passenger_app_env production;
     passenger_max_request_queue_size 200;
     passenger_ruby /usr/local/rvm/rubies/ruby-2.3.1/bin/ruby;


### PR DESCRIPTION
This causes nginx to fail to start the backend server.