### PR TITLE
Remove unnecessary Elasticsearch tasks

### DIFF
--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -11,19 +11,4 @@ namespace :elasticsearch do
     Verse.__elasticsearch__.import force: true
   end
 
-  desc 'setup elasticsearch files'
-  task setup_files: :environment do
-    analysis_dir = '/usr/local/etc/elasticsearch/analysis'
-
-    Dir.mkdir(analysis_dir) unless File.exist?(analysis_dir)
-
-    Dir['config/elasticsearch/analysis/*'].each do |curr_path|
-      File.open(
-        "/usr/local/etc/elasticsearch/analysis/#{Pathname.new(curr_path).basename}",
-        'w'
-      ) do |f|
-        f.write(File.open(curr_path).read)
-      end if File.file?(curr_path)
-    end
-  end
 end


### PR DESCRIPTION
Elasticsearch runs sandboxed away from api, so these files aren't
available to api anyway.