### PR TITLE
Update Passenger Docker images to 0.9.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-customizable:0.9.20
+FROM phusion/passenger-customizable:0.9.24
 
 # set correct environment variables
 ENV HOME /root


### PR DESCRIPTION
This allows Phusion Passenger to be upgraded to 5.1.8, which fixes some
security issues.