### PR TITLE
add range search

### DIFF
--- a/app/models/concerns/quran_navigation_searchable.rb
+++ b/app/models/concerns/quran_navigation_searchable.rb
@@ -185,6 +185,7 @@ module QuranNavigationSearchable
       "ch#{chapter_id}v#{verse_number}", # ch23v2
       "c#{chapter_id}v#{verse_number}", # v2v3
       "#{chapter.name_arabic} #{verse_number}", # الفاتحة 1
+      "#{chapter.name_simple} #{verse_number}", # Al-Baqarah 1
       "surah #{chapter_id} ayah #{verse_number}", # surah 1 ayah 1
       "ayah #{verse_number} surah #{chapter_id}", # ayah 1 surah 1
     ]

--- a/lib/qdc/search/navigational_ayah_range_result.rb
+++ b/lib/qdc/search/navigational_ayah_range_result.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Qdc
+  module Search
+    class NavigationalAyahRangeResult < NavigationalResults
+      def initialize(range)
+        @matched_range = range
+      end
+
+      def empty?
+        false
+      end
+
+      def total_count
+        1
+      end
+
+      def range?
+        true
+      end
+
+      protected
+      def prepare_results
+        surah = Chapter.find_using_slug(@matched_range['surah'])
+        ayah_from = @matched_range['from'].to_i
+        ayah_to = @matched_range['to'].to_i
+
+        from = [1, [ayah_from, ayah_to].min].max
+        to = [surah.verses_count, [ayah_from, ayah_to].max].min
+
+        [
+          {
+            result_type: 'range',
+            name: "Surah #{surah.name_simple}, verse #{from} to #{to}",
+            key: "#{surah.id}:#{from}-#{to}"
+          }
+        ]
+      end
+    end
+  end
+end

--- a/lib/qdc/search/navigational_results.rb
+++ b/lib/qdc/search/navigational_results.rb
@@ -19,6 +19,10 @@ module Qdc
         @search.empty?
       end
 
+      def range?
+        false
+      end
+
       def total_count
         @search.response['hits']['total']['value']
       end

--- a/lib/qdc/search/query.rb
+++ b/lib/qdc/search/query.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'cld3'
 module Qdc
   module Search
     class Query < ::Search::Query

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require 'cld3'
+
 module Search
   class Query
     attr_reader :query # rubocop:disable
     include QuranUtils::StrongMemoize
 
     LANG_DETECTOR_CLD3 = CLD3::NNetLanguageIdentifier.new(0, 2000)
+    REGEXP_AYAH_RANGE = /^(?<surah>\d+)[\s\/:-]+(?<from>\d+)[\s\/:-]+(?<to>\d+)$/
+    REGEXP_AYAH_KEY = /^(?<surah>\d+)[\/:\\](?<ayah>\d+)$/
 
     def initialize(query)
       @query = query.to_s.strip
@@ -20,8 +23,12 @@ module Search
       detect_languages == ['ar']
     end
 
-    def has_ayah_key?
-      query.match? /[\/:\\]/
+    def is_ayah_key_query?
+      REGEXP_AYAH_KEY.match query
+    end
+
+    def is_range_query?
+      REGEXP_AYAH_RANGE.match query
     end
 
     def detect_languages


### PR DESCRIPTION
Add support for range search in navigation API. Supporting following range formats:

2:68-70
1:2:3
2-3-5
2-3:5
2/3-5
2/3/5

Sample output
```
{
 "result_type": "range",
 "name": "Surah Yunus, verse 20 to 30",
 "key": "10:20-30"
}
```
