### PR TITLE
Fix missing ayah for filters api

### DIFF
--- a/app/finders/qdc/verse_finder.rb
+++ b/app/finders/qdc/verse_finder.rb
@@ -42,7 +42,8 @@ class Qdc::VerseFinder < ::VerseFinder
       tafsirs: tafsirs,
       translations: translations,
       reciter: reciter,
-      filter: filter
+      filter: filter,
+      verse_order: 'filter' == filter ? '' : 'verses.verse_index ASC'
     )
   end
 
@@ -71,20 +72,20 @@ class Qdc::VerseFinder < ::VerseFinder
     end
   end
 
-  def load_related_resources(language:, mushaf:, words:, tafsirs:, translations:, reciter:, filter:)
+  def load_related_resources(language:, mushaf:, words:, tafsirs:, translations:, reciter:, filter:, verse_order: 'verses.verse_index ASC')
     load_translations(translations) if translations.present?
     load_words(language, mushaf) if words
     load_segments(reciter) if reciter
     load_tafsirs(tafsirs) if tafsirs.present?
 
     words_ordering = if words
-                       ', mushaf_words.position_in_verse ASC, word_translations.priority ASC'
+                       "#{verse_order.present? ? ',' : ''} mushaf_words.position_in_verse ASC, word_translations.priority ASC"
                      else
                        ''
                      end
 
     translations_order = translations.present? ? ', translations.priority ASC' : ''
-    @results.order("verses.verse_index ASC #{words_ordering} #{translations_order}".strip)
+    @results.order("#{verse_order} #{words_ordering} #{translations_order}".strip)
   end
 
   def fetch_advance_copy

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -38,7 +38,7 @@ Pagy::DEFAULT[:items]  = 10                                 # default
 
 # Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
 # See https://ddnexus.github.io/pagy/extras/array
-# require 'pagy/extras/array'
+#require 'pagy/extras/array'
 
 # Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
 # See https://ddnexus.github.io/pagy/extras/calendar


### PR DESCRIPTION
Filters query is complex, preloading data from couple of tables, multiple order and where clauses. LIMTI and OFFSET wasn't' working for some reason. We've migrated most apis to use "pagy" for pagination. Pagy trick works here as well. 