### PR TITLE
get resource changes after date API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 #### Requirements
 - Rails 5.0.1
 - Elasticsearch 5.0.1
-- Ruby 3.0.0
+- Ruby 3.1.0
 
 #### Installations
 Gems:
@@ -33,18 +33,19 @@ PostgreSQL: clusterdb createdb createlang createuser dropdb droplang dropuser ec
 
 See: http://postgresapp.com/documentation/cli-tools.html
 
-### Database 
+### Database
 It's private, we will not share complete dump. If you need mini version for contributing to quran.com, please join our slack channel and ask one of project's collaborator for access.
 
 ### Usage
-
 ```
-http://localhost:3000/api/v3/chapters/1/verses
+http://localhost:3000/api/v4/chapters/1
 ```
 
 ### Documentation
+https://quran.api-docs.io/v4/
 
-https://quran.api-docs.io/v3
+Note that v3 is no longer being extended or fixed. For migration guide for v3 -> v4
+see: https://quran.api-docs.io/v4/getting-started/api-v3-v4-migration-guide
 
 ## Community
 Join Quran.com community here https://quran-community.herokuapp.com

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ http://localhost:3000/api/v4/chapters/1
 ### Documentation
 https://quran.api-docs.io/v4/
 
-Note that v3 is no longer being extended or fixed. For migration guide for v3 -> v4
+Note that v3 is no longer being extended or fixed. For v3 -> v4 migration guide
 see: https://quran.api-docs.io/v4/getting-started/api-v3-v4-migration-guide
 
 ## Community

--- a/app/controllers/api/v4/resources_controller.rb
+++ b/app/controllers/api/v4/resources_controller.rb
@@ -108,15 +108,12 @@ module Api::V4
     end
 
     def changes
-      updated_after = params[:updated_after]
-      @resources = ResourceContent.changes(updated_after)
-
-      if valid_time?(updated_after) || updated_after.blank?
-        render
+      if time = after_timestamp
+         @resources = ResourceContent.changes(time)
+         render
       else
-        render_422("Invalid datetime format")
+        render_422("Pass in valid datetime")
       end
-
     end
   end
 end

--- a/app/controllers/api/v4/resources_controller.rb
+++ b/app/controllers/api/v4/resources_controller.rb
@@ -108,9 +108,15 @@ module Api::V4
     end
 
     def changes
-      @resources = ResourceContent.changes(params[:updated_after])
+      updated_after = params[:updated_after]
+      @resources = ResourceContent.changes(updated_after)
 
-      render
+      if valid_time?(updated_after) || updated_after.blank?
+        render
+      else
+        render_422("Invalid datetime format")
+      end
+
     end
   end
 end

--- a/app/controllers/api/v4/resources_controller.rb
+++ b/app/controllers/api/v4/resources_controller.rb
@@ -106,5 +106,11 @@ module Api::V4
 
       render
     end
+
+    def changes
+      @resources = ResourceContent.changes(params[:updated_after])
+
+      render
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,10 @@ class ApplicationController < ActionController::API
     render partial: "api/errors/404", locals: { message: error.to_s }, status: :not_found
   end
 
+  def render_422(error=nil)
+    render partial: "api/errors/422", locals: { message: error.to_s }, status: :unprocessable_entity
+  end
+
   def fetch_locale
     params[:language].presence || params[:locale].presence || 'en'
   end
@@ -53,5 +57,12 @@ class ApplicationController < ActionController::API
         .or(defaults)
         .order('translated_names.language_priority DESC')
     end
+  end
+
+  def valid_time?(datetime)
+    Time.strptime(datetime, "%Y-%m-%dT%H:%M:%S")
+    true
+  rescue
+    false
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,10 +59,9 @@ class ApplicationController < ActionController::API
     end
   end
 
-  def valid_time?(datetime)
-    Time.strptime(datetime, "%Y-%m-%dT%H:%M:%S")
-    true
-  rescue
-    false
+  def after_timestamp
+    if time = params[:updated_after].presence
+      time !~ /\D/ ? DateTime.strptime(time, '%s') : Time.parse(time)
+    end
   end
 end

--- a/app/models/resource_content.rb
+++ b/app/models/resource_content.rb
@@ -57,6 +57,7 @@ class ResourceContent < ApplicationRecord
   scope :one_chapter, -> { where cardinality_type: CardinalityType::OneChapter }
   scope :approved, -> { where approved: true }
   scope :recitations, -> { where sub_type: SubType::Audio }
+  scope :changes, ->(updated_after = nil) { where("updated_at > ?" , updated_after) }
 
   module CardinalityType
     OneVerse = '1_ayah'

--- a/app/models/resource_content.rb
+++ b/app/models/resource_content.rb
@@ -57,7 +57,8 @@ class ResourceContent < ApplicationRecord
   scope :one_chapter, -> { where cardinality_type: CardinalityType::OneChapter }
   scope :approved, -> { where approved: true }
   scope :recitations, -> { where sub_type: SubType::Audio }
-  scope :changes, ->(updated_after = nil) { where("updated_at > ?" , updated_after) }
+  scope :changes, ->(updated_after) { where("updated_at > ?", updated_after) }
+
 
   module CardinalityType
     OneVerse = '1_ayah'

--- a/app/models/resource_content.rb
+++ b/app/models/resource_content.rb
@@ -57,8 +57,6 @@ class ResourceContent < ApplicationRecord
   scope :one_chapter, -> { where cardinality_type: CardinalityType::OneChapter }
   scope :approved, -> { where approved: true }
   scope :recitations, -> { where sub_type: SubType::Audio }
-  scope :changes, ->(updated_after) { where("updated_at > ?", updated_after) }
-
 
   module CardinalityType
     OneVerse = '1_ayah'
@@ -94,4 +92,13 @@ class ResourceContent < ApplicationRecord
     stats = resource_content_stat || create_resource_content_stat
     stats.update_column :download_count, stats.download_count.to_i + 1
   end
+
+  def self.changes(updated_after)
+    if updated_after.present?
+      where("updated_at > ?", updated_after)
+    else
+      all
+    end
+  end
+
 end

--- a/app/views/api/errors/_422.json.streamer
+++ b/app/views/api/errors/_422.json.streamer
@@ -1,0 +1,4 @@
+json.object! do
+  json.status 422
+  json.error message || 'Semantic error in request.'
+end

--- a/app/views/api/v4/resources/changes.json.streamer
+++ b/app/views/api/v4/resources/changes.json.streamer
@@ -7,11 +7,8 @@ json.object! do
                       :name,
                       :updated_at,
                       :resource_type,
-                      :resource_type_name,
                       :cardinality_type,
-                      :description,
                       :language_name,
-                      :resource_info,
                       :slug,
                       :sub_type
 

--- a/app/views/api/v4/resources/changes.json.streamer
+++ b/app/views/api/v4/resources/changes.json.streamer
@@ -1,0 +1,22 @@
+json.object! do
+  json.changes do
+    json.array! @resources do |resource|
+      json.object! do
+        json.extract! resource,
+                      :id,
+                      :name,
+                      :updated_at,
+                      :resource_type,
+                      :resource_type_name,
+                      :cardinality_type,
+                      :description,
+                      :language_name,
+                      :resource_info,
+                      :slug,
+                      :sub_type
+
+
+      end
+    end
+  end
+end

--- a/config/routes/api/v4.rb
+++ b/config/routes/api/v4.rb
@@ -76,7 +76,7 @@ namespace :v4 do
     get :chapter_infos
     get :verse_media
     get :chapter_reciters
-    get 'changes/', action: 'changes'
+    get :changes
   end
 
   # routes for fetching all records of one resource.

--- a/config/routes/api/v4.rb
+++ b/config/routes/api/v4.rb
@@ -76,6 +76,7 @@ namespace :v4 do
     get :chapter_infos
     get :verse_media
     get :chapter_reciters
+    get 'changes/', action: 'changes'
   end
 
   # routes for fetching all records of one resource.


### PR DESCRIPTION
**Objective**
1. Created `GET /changes?updated_after={date_time}` endpoint to get all resources updated after `date_time` + error handling when invalid datetime format given.
2. Minor changes in README to reflect ruby version update + documentation details

**Questions**
1. Any tips on how I can get `resource_id` to be passed in as an optional query param, but still keeping the grabbing of `date_time` maintainable (date_time is filtered via scope)? Tried to see how yall were filtering params, etc now but got lost (still new to rails/ruby), k
2. Where are  unit tests located? I tried to find them but couldn't, thought they'd be in /test but no such directory
3. Are the resource data being shown in `app/views/api/v4/resources/changes.json.streamer` fine? Not familiar with what people who'd use this endpoint would want to know besides what's there.

**Resolves**: https://github.com/quran/quran.com-api/issues/575
