### PR TITLE
Add protobuf to fix GitHub action failure

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install protobuf
+        run: sudo apt install -y protobuf-compiler
       # Add or replace dependency steps here
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@8f312efe1262fb463d906e9bf040319394c18d3e # v1.92
@@ -45,6 +47,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install protobuf
+        run: sudo apt install -y protobuf-compiler
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@8f312efe1262fb463d906e9bf040319394c18d3e # v1.92
         with:


### PR DESCRIPTION
This should fix github action failure caused by gem installation for the cld3 package.