### PR TITLE
Update README.md to include updated V4 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ http://localhost:3000/api/v4/chapters/1
 ```
 
 ### Documentation
-https://quran.api-docs.io/v4/
+V4 docs: https://api-docs.quran.com/quran.com/v4/
+deprecated V4 docs: https://quran.api-docs.io/v4/
 
 Note that v3 is no longer being extended or fixed. For v3 -> v4 migration guide
 see: https://quran.api-docs.io/v4/getting-started/api-v3-v4-migration-guide


### PR DESCRIPTION
- I was going through the old v4 docs and had a question that I posted in Discord, upon asking I was pointed to the updated V4 docs. 
- discord reference: https://discord.com/channels/852441853386293268/852441853852647449/1108068986832306389
- message from discord: `quran.api-docs.io is the old docs platform and will be removed soon. Please use https://api-docs.quran.com/quran.com/v4/operations/verse-media. The API seems to be working fine.`