### PR TITLE
fix(verses-api): support multi-verse tafsirs in verses endpoint

### DIFF
--- a/app/presenters/verses_presenter.rb
+++ b/app/presenters/verses_presenter.rb
@@ -261,7 +261,6 @@ class VersesPresenter < BasePresenter
         approved_tafsirs = ResourceContent
                              .approved
                              .tafsirs
-                             .one_verse
                              .allowed_to_share
 
         params[:tafsirs] = approved_tafsirs


### PR DESCRIPTION
This PR enables support for multi-verse tafsirs in the `/verses/by_key` endpoint. 

🔧 **Fix Summary:**
- Removes the `one_verse` constraint from the `VersesPresenter` logic.
- Allows tafsir resources like Ibn Kathir (ID 169), which span multiple verses, to appear correctly in the response.

✅ Tested locally with verse key `2:2` and tafsir ID `169`.
